### PR TITLE
fix: optional npm dependency install failure

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: lts/*
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       - name: Install Playwright Browsers
         run: npx playwright install
       - name: Run e2e tests


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/playwright.yml` file. The change replaces the `npm ci` command with `npm install` for installing dependencies due to https://github.com/npm/cli/issues/4828 