### PR TITLE
build: preload fonts, dont include fonts in weights that aren't used to reduce bundle size

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
   </head>
   <body>
     <div id="root"></div>
+    <link rel="stylesheet" href="/fonts/Matter-Regular.woff2" as="font" preload />
+    <link rel="stylesheet" href="/fonts/Matter-Medium.woff2" as="font" preload />
+    <link rel="stylesheet" href="/fonts/Matter-Semibold.woff2" as="font" preload />
+    <link rel="stylesheet" href="/fonts/Matter-Bold.woff2" as="font" preload />
+
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/theme.css
+++ b/src/theme.css
@@ -2,14 +2,6 @@
 
 @font-face {
     font-family: 'Matter', sans-serif;
-    src: url('./assets/fonts/Matter-Light.woff2') format('woff2');
-    font-weight: 300; /* Light */
-    font-style: normal;
-    display: swap;
-}
-
-@font-face {
-    font-family: 'Matter', sans-serif;
     src: url('./assets/fonts/Matter-Regular.woff2') format('woff2');
     font-weight: 400; /* Regular */
     font-style: normal;
@@ -40,14 +32,6 @@
     display: swap;
 }
 
-@font-face {
-    font-family: 'Matter', sans-serif;
-    src: url('./assets/fonts/Matter-Heavy.woff2') format('woff2');
-    font-weight: 800; /* Heavy */
-    font-style: normal;
-    display: swap;
-}
-
 .radix-themes {
     --font-weight-light: 300;
     --font-weight-regular: 400;
@@ -55,7 +39,7 @@
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
     --default-font-family: 'Matter', sans-serif;
-    --heading-font-family: 'Matter';
+    --heading-font-family: 'Matter', sans-serif;
     --strong-font-family: 'Matter';
 }
 


### PR DESCRIPTION
This pull request focuses on optimizing font loading and cleaning up unused font-face declarations in the project. The changes aim to improve performance by preloading fonts and simplifying the `theme.css` file.

### Font loading improvements:

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R11-R15): Added `<link>` tags to preload commonly used fonts (`Matter-Regular`, `Matter-Medium`, `Matter-Semibold`, and `Matter-Bold`) to enhance performance by reducing font loading time.

### Cleanup of unused font-face declarations:

* [`src/theme.css`](diffhunk://#diff-dbf45880b4ebcdc9dbc9d77933b08fc94c45069387a7fb793e3f5e558fae94c4L3-L10): Removed unused `@font-face` declarations for `Matter-Light` and `Matter-Heavy`, as these fonts are no longer required in the project. [[1]](diffhunk://#diff-dbf45880b4ebcdc9dbc9d77933b08fc94c45069387a7fb793e3f5e558fae94c4L3-L10) [[2]](diffhunk://#diff-dbf45880b4ebcdc9dbc9d77933b08fc94c45069387a7fb793e3f5e558fae94c4L43-R42)
* [`src/theme.css`](diffhunk://#diff-dbf45880b4ebcdc9dbc9d77933b08fc94c45069387a7fb793e3f5e558fae94c4L43-R42): Adjusted `--heading-font-family` to include the fallback `sans-serif` for better font rendering consistency.