### PR TITLE
chore: remove privileges navigation item

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,7 @@
 import '@radix-ui/themes/styles.css';
 import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
-import {
-    AppList,
-    GroupList,
-    NotFoundPage,
-    OAuthRedirectPage,
-    OAuthTriggerPage,
-    PrivilegeList,
-    UserList,
-} from './pages';
+import { AppList, GroupList, NotFoundPage, OAuthRedirectPage, OAuthTriggerPage, UserList } from './pages';
 import './theme.css';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -53,14 +45,6 @@ function App() {
                                 element={
                                     <Protected>
                                         <ApiSandbox />
-                                    </Protected>
-                                }
-                            />
-                            <Route
-                                path={CLIENT_ROUTES.PRIVILEGES_TABLE}
-                                element={
-                                    <Protected>
-                                        <PrivilegeList />
                                     </Protected>
                                 }
                             />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { GlobeIcon, GridIcon, LockClosedIcon, PersonIcon, RocketIcon } from '@radix-ui/react-icons';
+import { GlobeIcon, GridIcon, PersonIcon, RocketIcon } from '@radix-ui/react-icons';
 import { Flex, Theme } from '@radix-ui/themes';
 import { useMemo } from 'react';
 import { Outlet } from 'react-router-dom';
@@ -15,7 +15,6 @@ export default function Layout() {
             { name: 'Users', icon: <PersonIcon />, count: 14, path: CLIENT_ROUTES.USERS_TABLE },
             { name: 'Groups', icon: <GlobeIcon />, count: 5, path: CLIENT_ROUTES.GROUPS_TABLE },
             { name: 'Apps', icon: <GridIcon />, count: 2, path: CLIENT_ROUTES.APPS_TABLE },
-            { name: 'Privileges', icon: <LockClosedIcon />, count: 0, path: CLIENT_ROUTES.PRIVILEGES_TABLE },
             { name: 'Sandbox', icon: <RocketIcon />, count: 0, path: CLIENT_ROUTES.USERS_SANDBOX },
         ],
         [],


### PR DESCRIPTION
Removes routing to privileges through the sidebar and through `/privileges/table`

Resolves issue #28 